### PR TITLE
feat(copilot-cli): add jailed home module

### DIFF
--- a/.claude/skills/project-manager/SKILL.md
+++ b/.claude/skills/project-manager/SKILL.md
@@ -6,7 +6,7 @@ ______________________________________________________________________
 - Use the `github-personal` MCP for other GitHub operations, not supported by the gh-project-manager CLI
 - Use the `gh-personal` GitHub CLI wrapper for special queries and commands, not supported by the two options mentioned
   above
-- The `gh-personal` & `gh-work` CLI wrappers is replacements for the `gh` CLI.
+- The `gh-personal` & `gh-work` CLI wrappers are replacements for the `gh` CLI.
 
 ## How to use the gh-project-manager CLI
 

--- a/home-modules/copilot-cli/default.nix
+++ b/home-modules/copilot-cli/default.nix
@@ -1,0 +1,119 @@
+{
+  config,
+  pkgs,
+  lib,
+  inputs,
+  ...
+}: let
+  readSkillsFrom = dir:
+    builtins.mapAttrs (name: _: dir + "/${name}")
+    (lib.filterAttrs (_: type: type == "directory") (builtins.readDir dir));
+in {
+  options.modules.copilot-cli = with lib; {
+    enable = mkEnableOption "GitHub Copilot CLI with jail sandbox";
+
+    preSetupScripts = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = "Shell scripts to source before running Copilot CLI";
+    };
+
+    runtimeInputs = mkOption {
+      type = types.listOf types.package;
+      default = [];
+      description = "Additional packages to add to PATH inside the jail";
+    };
+
+    mcpServers = mkOption {
+      type = types.attrsOf types.anything;
+      default = {};
+      description = "MCP server config written to ~/.copilot/mcp-config.json";
+    };
+  };
+
+  config = let
+    cfg = config.modules.copilot-cli;
+    jail = inputs.jail-nix.lib.init pkgs;
+
+    copilot-pkg = pkgs.github-copilot-cli;
+
+    settingsJSON = builtins.toJSON {
+      mcpServers = cfg.mcpServers;
+    };
+
+    copilot-azure-devops-mcp-wrapper = pkgs.writeShellApplication {
+      name = "copilot-azure-devops-mcp";
+      runtimeInputs = [
+        pkgs.fish
+        pkgs.coreutils
+        pkgs.local.azure-devops-mcp
+      ];
+      checkPhase = "true";
+      text = ''
+        exec ${pkgs.fish}/bin/fish ${./scripts/copilot-azure-devops-mcp.fish} "$@"
+      '';
+    };
+
+    jailed-copilot = jail "copilot" copilot-pkg (
+      with jail.combinators; [
+        network
+        no-new-session
+        mount-cwd
+        (ro-bind "/nix/store" "/nix/store")
+        (try-readwrite (noescape "~/.cache/copilot-cli"))
+        (try-readwrite (noescape "~/.config/copilot-cli"))
+        (try-readwrite (noescape "~/.copilot"))
+        (try-readwrite (noescape "~/.local/share/copilot-cli"))
+        (try-readonly (noescape "~/.config/git"))
+        (try-readonly (noescape "~/.gitconfig"))
+        (try-readonly (noescape "~/.ssh"))
+        (fwd-env "GH_TOKEN")
+        (fwd-env "GITHUB_TOKEN")
+        (fwd-env "GH_HOST")
+        (fwd-env "COPILOT_CLI_SETTINGS")
+        (fwd-env "AZURE_DEVOPS_ORG")
+        (fwd-env "AZURE_DEVOPS_PAT")
+        (fwd-env "SSH_AUTH_SOCK")
+        (try-readonly (noescape "~/.1password/agent.sock"))
+        (add-pkg-deps ([
+            pkgs.git
+            pkgs.gh
+            pkgs.ripgrep
+            pkgs.bash
+            pkgs.fish
+            copilot-pkg
+            pkgs.fishPlugins.github-copilot-cli-fish
+            copilot-azure-devops-mcp-wrapper
+          ]
+          ++ cfg.runtimeInputs))
+      ]
+    );
+
+    copilot-wrapper = pkgs.writeShellApplication {
+      name = "copilot-jailed";
+      runtimeInputs = [jailed-copilot];
+      checkPhase = "true"; # Skip shellcheck - preSetupScripts may have dynamic paths
+      text = ''
+        ${lib.concatMapStrings (script: ''
+            . ${script}
+          '')
+          cfg.preSetupScripts}
+
+        exec ${lib.getExe jailed-copilot} "$@"
+      '';
+    };
+  in
+    lib.mkIf cfg.enable {
+      home.packages = [copilot-wrapper];
+
+      home.file = lib.mkMerge [
+        {".copilot/mcp-config.json".text = settingsJSON;}
+        (lib.mapAttrs' (name: path:
+          lib.nameValuePair ".copilot/skills/${name}" {
+            source = path;
+            recursive = true;
+          })
+        (readSkillsFrom ./skills))
+      ];
+    };
+}

--- a/home-modules/copilot-cli/scripts/copilot-azure-devops-mcp.fish
+++ b/home-modules/copilot-cli/scripts/copilot-azure-devops-mcp.fish
@@ -1,0 +1,20 @@
+#!/usr/bin/env fish
+# Azure DevOps MCP wrapper for Copilot CLI jail.
+# Converts AZURE_DEVOPS_PAT into the base64-encoded PERSONAL_ACCESS_TOKEN
+# format that azure-devops-mcp expects: base64("<user>:<pat>").
+# The username is ignored by Azure DevOps, so we use "copilot" as a placeholder.
+
+set -l org $AZURE_DEVOPS_ORG
+
+if test -z "$org"
+    echo "AZURE_DEVOPS_ORG must be set before starting Azure DevOps MCP." >&2
+    exit 1
+end
+
+if test -z "$AZURE_DEVOPS_PAT"
+    echo "AZURE_DEVOPS_PAT must be set before starting Azure DevOps MCP." >&2
+    exit 1
+end
+
+set -gx PERSONAL_ACCESS_TOKEN (printf 'copilot:%s' $AZURE_DEVOPS_PAT | base64 | string collect -N)
+exec azure-devops-mcp $org --authentication pat $argv


### PR DESCRIPTION
## Summary
- Add `home-modules/copilot-cli/default.nix` — a Home Manager module that creates a jailed `copilot-jailed` wrapper using jail-nix for namespace isolation
- Follows the exact pattern from `home-modules/opencode/default.nix`
- Options: `enable`, `preSetupScripts`, `runtimeInputs`

Closes #61