### PR TITLE
feat(wsl-cab): remove deprecated MCP packages

### DIFF
--- a/.claude/skills/project-manager/SKILL.md
+++ b/.claude/skills/project-manager/SKILL.md
@@ -6,6 +6,7 @@ ______________________________________________________________________
 - Use the `github-personal` MCP for other GitHub operations, not supported by the gh-project-manager CLI
 - Use the `gh-personal` GitHub CLI wrapper for special queries and commands, not supported by the two options mentioned
   above
+- The `gh-personal` & `gh-work` CLI wrappers is replacements for the `gh` CLI.
 
 ## How to use the gh-project-manager CLI
 

--- a/home-modules/opencode/default.nix
+++ b/home-modules/opencode/default.nix
@@ -56,6 +56,7 @@
             pkgs.git
             pkgs.ripgrep
             pkgs.bash
+            pkgs.fish
             pkgs._1password-gui
           ]
           ++ cfg.runtimeInputs))

--- a/hosts/orion/modules/opencode.nix
+++ b/hosts/orion/modules/opencode.nix
@@ -16,8 +16,12 @@
         inputs.mcp-nixos.packages.${pkgs.stdenv.hostPlatform.system}.mcp-nixos
         pkgs.local.github-personal-mcp
         pkgs.local.github-work-mcp
+        pkgs.local.gh-personal # GitHub CLI authenticated with PAT for personal account
+        pkgs.local.gh-personal-project-manager # GitHub CLI with classic PAT for project management
+        pkgs.local.gh-work # GitHub CLI authenticated with PAT for work account
         self.formatter.${pkgs.stdenv.hostPlatform.system} # treefmt wrapper (all formatters)
         pkgs.findutils # find, xargs, locate
+        pkgs.jq # command-line JSON processor
         inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.ck # hybrid code search (semantic, lexical, regex)
       ];
     };

--- a/hosts/wsl-cab/configuration.nix
+++ b/hosts/wsl-cab/configuration.nix
@@ -9,7 +9,6 @@
 }: {
   imports = [
     "${self}/modules/defaults.nix"
-    "${self}/modules/markitdown-mcp/default.nix"
   ];
 
   nixpkgs = {
@@ -60,8 +59,6 @@
     nix-ld.enable = true;
   };
 
-  services.markitdown-mcp.enable = true;
-
   environment = {
     systemPackages = let
       base = with pkgs; [
@@ -79,10 +76,7 @@
         icu
         azure-cli
         inputs.mcp-nixos.packages.${pkgs.stdenv.hostPlatform.system}.mcp-nixos
-        pkgs.python313Packages.markitdown
         local.azure-mcp-server
-        local.github-mcp-server
-        local.mcp-nuget
       ];
     in
       base;

--- a/hosts/wsl-cab/home.nix
+++ b/hosts/wsl-cab/home.nix
@@ -28,16 +28,13 @@
       grc
       gitleaks
       nuget
-      local.awesome-copilot
       unstable.playwright-mcp
-      unstable.mcp-grafana
       unstable.mcp-proxy
       (dotnetCorePackages.combinePackages [
         dotnetCorePackages.dotnet_9.sdk
         dotnetCorePackages.dotnet_10.sdk
       ])
       unstable.nodejs_24
-      local.context7-mcp
       local.azure-devops-mcp
     ];
   };


### PR DESCRIPTION
## Summary
- Remove 6 MCP packages being replaced by jailed Copilot CLI
- Remove: `mcp-nuget`, `github-mcp-server`, `markitdown` from system config
- Remove: `awesome-copilot`, `mcp-grafana`, `context7-mcp` from home config
- Remove `markitdown-mcp` service and module import
- Keep: `mcp-nixos`, `azure-mcp`, `playwright`, `mcp-proxy`, `azure-devops`

Closes #60